### PR TITLE
Group search results by unique Arkivskaper

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,6 +100,9 @@ th {
 td {
   background-color: #f2f2f2;
 }
+td div {
+  margin-bottom: 2px;
+}
 tr:nth-child(even) td {
   background-color: #f2f2f2;
 }


### PR DESCRIPTION
## Summary
- group search results by `ASTA-id`/`Arkivskaper` pairs
- include multiple series placements under each unique pair
- adjust click handler for nested elements
- style multiline table cells

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68610dbfd70c83299cca9def74cf00b3