### PR TITLE
Improve results readability

### DIFF
--- a/script.js
+++ b/script.js
@@ -49,17 +49,17 @@ function groupResults(data) {
 
 function createGroupRow(group) {
   const row = $("<tr></tr>");
-  row.append($("<td></td>").text(group.id));
-  row.append($("<td></td>").text(group.arkivskaper));
+  row.append($("<td class='group-id'></td>").text(group.id));
+  row.append($("<td class='group-arkivskaper'></td>").text(group.arkivskaper));
 
   const serieCell = $("<td></td>");
   const fromCell = $("<td></td>");
   const toCell = $("<td></td>");
 
   group.series.forEach(entry => {
-    serieCell.append($("<div></div>").text(entry.serie));
-    fromCell.append($("<div></div>").text(entry.from));
-    toCell.append($("<div></div>").text(entry.to));
+    serieCell.append($("<div class='result-item'></div>").text(entry.serie));
+    fromCell.append($("<div class='result-item'></div>").text(entry.from));
+    toCell.append($("<div class='result-item'></div>").text(entry.to));
   });
 
   row.append(serieCell, fromCell, toCell);

--- a/style.css
+++ b/style.css
@@ -103,6 +103,20 @@ td {
 td div {
   margin-bottom: 2px;
 }
+tbody tr {
+  border-bottom: 2px solid #ccc;
+}
+tbody td:first-child,
+tbody td:nth-child(2) {
+  font-weight: 600;
+}
+.result-item {
+  padding: 2px 0;
+  border-bottom: 1px solid #ddd;
+}
+.result-item:last-child {
+  border-bottom: none;
+}
 tr:nth-child(even) td {
   background-color: #f2f2f2;
 }


### PR DESCRIPTION
## Summary
- highlight group headings
- visually separate groups and individual results

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686114efcd84832980297833c4ce05e5